### PR TITLE
fix(grouped-nodes): only include root nodes as grouped nodes

### DIFF
--- a/docs/rules/pinia-setup-newlines-between-groups.md
+++ b/docs/rules/pinia-setup-newlines-between-groups.md
@@ -18,6 +18,8 @@ Below are the different groups (default):
 
 The order of the groups is determined by the settings object. Please read the [settings docs](https://github.com/programic/eslint-plugin/blob/master/docs/settings.md).
 
+Note: only direct children of the store setup function root will be included by this rule.
+
 ## :gear: Options
 ```json
 {

--- a/docs/rules/pinia-setup-order.md
+++ b/docs/rules/pinia-setup-order.md
@@ -16,5 +16,7 @@ The order is seperated into multiple groups. The default group order is:
 
 You can change the order via the `settings` options. Please read the [settings docs](https://github.com/programic/eslint-plugin/blob/master/docs/settings.md).
 
+Note: only direct children of the store setup function root will be included by this rule.
+
 ## :gear: Options
 Nothing.

--- a/docs/rules/vue-script-setup-newlines-between-groups.md
+++ b/docs/rules/vue-script-setup-newlines-between-groups.md
@@ -23,6 +23,8 @@ Below are the different groups (default):
 
 The order of the groups is determined by the settings object. Please read the [settings docs](https://github.com/programic/eslint-plugin/blob/master/docs/settings.md).
 
+Note: only direct children of the script setup root will be included by this rule.
+
 ## :gear: Options
 ```json
 {

--- a/docs/rules/vue-script-setup-order.md
+++ b/docs/rules/vue-script-setup-order.md
@@ -21,5 +21,7 @@ The order is seperated into multiple groups. The default group order is:
 
 You can change the order via the `settings` options. Please read the [settings docs](https://github.com/programic/eslint-plugin/blob/master/docs/settings.md).
 
+Note: only direct children of the script setup root will be included by this rule.
+
 ## :gear: Options
 Nothing.

--- a/lib/rules/pinia-setup-newlines-between-groups.js
+++ b/lib/rules/pinia-setup-newlines-between-groups.js
@@ -1,13 +1,13 @@
 const { ReferenceTracker } = require('eslint-utils');
 const {
-  getParentNode,
-  isVariableNode,
-  isFunctionNode,
-  getAncestorNode,
   getPiniaGroupOrder,
   getWatchersTraceMap,
+  isValidStoreDefinition,
   piniaDefineStoreTraceMap,
-  isFunctionDeclarationNode,
+  addNodeToStoreDefinition,
+  getChildNodesInStoreSetup,
+  getFilledStoreDefinitions,
+  getGroupedNodesInStoreSetup,
   getNumberOfEmptyLinesBetween,
   getComputedPropertiesTraceMap,
 } = require('../utils');
@@ -54,77 +54,6 @@ module.exports = {
       return `There must be exactly ${numberOfNewlines} ${newlinesWord} between each group ${detected}`;
     }
 
-    function getGroupedNodesInStoreSetup(storeSetupFunctionBody) {
-      const groupedNodes = getInitialGroupedNodes();
-
-      storeSetupFunctionBody.forEach(node => {
-        if (isVariableNode(node)) {
-          groupedNodes.states.push(node);
-        }
-
-        if (isFunctionDeclarationNode(node)) {
-          groupedNodes.methods.push(node);
-        }
-      });
-
-      return groupedNodes;
-    }
-
-    function addStoreDefinition(node) {
-      if (node.arguments.length > 1) {
-        const storeDefinerNode = node.arguments[1];
-
-        if (
-          isFunctionNode(storeDefinerNode)
-          && Array.isArray(storeDefinerNode?.body?.body)
-        ) {
-          const storeSetupFunctionBody = storeDefinerNode.body.body;
-          const groupedNodes = getGroupedNodesInStoreSetup(storeSetupFunctionBody);
-
-          storeDefinitions.push({ storeSetupNode: node, groupedNodes });
-        }
-      }
-    }
-
-    function addNodeToStoreDefinition(node, nodeType) {
-      const storeItem = storeDefinitions.find(storeDefinition => {
-        return !!getAncestorNode(node, ancestorNode => {
-          return ancestorNode === storeDefinition.storeSetupNode;
-        });
-      });
-
-      if (storeItem && Array.isArray(storeItem.groupedNodes[nodeType])) {
-        storeItem.groupedNodes[nodeType].push(node);
-      }
-    }
-
-    function getStateNodesThatAreAbsentInOtherGroups(groupedNodes) {
-      const { states, ...groupedNonStateNodes } = groupedNodes;
-
-      const nonStateNodes = Object.values(groupedNonStateNodes).flat();
-      const nonStateVariableNodes = nonStateNodes.map(node => {
-        return getParentNode(getAncestorNode(node, isVariableNode));
-      }).filter(Boolean);
-
-      return states.filter(stateNode => {
-        return !nonStateVariableNodes.includes(stateNode);
-      });
-    }
-
-    function getFilledStoreDefinitions() {
-      return storeDefinitions.map(storeDefinition => {
-        return {
-          ...storeDefinition,
-          groupedNodes: {
-            ...storeDefinition.groupedNodes,
-            states: getStateNodesThatAreAbsentInOtherGroups(storeDefinition.groupedNodes),
-          },
-        };
-      }).filter(storeDefinition => {
-        return Object.values(storeDefinition.groupedNodes).flat().length > 0;
-      });
-    }
-
     return {
       Program() {
         const tracker = new ReferenceTracker(context.getScope());
@@ -135,20 +64,27 @@ module.exports = {
         };
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.piniaDefineStore)) {
-          addStoreDefinition(node);
+          if (isValidStoreDefinition) {
+            const groupedNodes = getGroupedNodesInStoreSetup(
+              getChildNodesInStoreSetup(node),
+              getInitialGroupedNodes(),
+            );
+
+            storeDefinitions.push({ storeSetupNode: node, groupedNodes });
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.computedProperties)) {
-          addNodeToStoreDefinition(node, 'computedProperties');
+          addNodeToStoreDefinition(storeDefinitions, node, 'computedProperties');
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.watchers)) {
-          addNodeToStoreDefinition(node, 'watchers');
+          addNodeToStoreDefinition(storeDefinitions, node, 'watchers');
         }
       },
       // eslint-disable-next-line object-shorthand
       'Program:exit'() {
-        storeDefinitions = getFilledStoreDefinitions();
+        storeDefinitions = getFilledStoreDefinitions(storeDefinitions);
 
         storeDefinitions.forEach(storeDefinition => {
           const { groupedNodes } = storeDefinition;

--- a/lib/rules/pinia-setup-newlines-inside-groups.js
+++ b/lib/rules/pinia-setup-newlines-inside-groups.js
@@ -1,14 +1,14 @@
 const { ReferenceTracker } = require('eslint-utils');
 const {
   piniaGroups,
-  getParentNode,
-  isVariableNode,
-  isFunctionNode,
-  getAncestorNode,
   getPiniaGroupOrder,
   getWatchersTraceMap,
+  isValidStoreDefinition,
   piniaDefineStoreTraceMap,
-  isFunctionDeclarationNode,
+  addNodeToStoreDefinition,
+  getChildNodesInStoreSetup,
+  getFilledStoreDefinitions,
+  getGroupedNodesInStoreSetup,
   getNumberOfEmptyLinesBetween,
   getComputedPropertiesTraceMap,
 } = require('../utils');
@@ -116,77 +116,6 @@ module.exports = {
       return Object.fromEntries(order.map(groupType => [groupType, []]));
     }
 
-    function getGroupedNodesInStoreSetup(storeSetupFunctionBody) {
-      const groupedNodes = getInitialGroupedNodes();
-
-      storeSetupFunctionBody.forEach(node => {
-        if (isVariableNode(node)) {
-          groupedNodes.states.push(node);
-        }
-
-        if (isFunctionDeclarationNode(node)) {
-          groupedNodes.methods.push(node);
-        }
-      });
-
-      return groupedNodes;
-    }
-
-    function addStoreDefinition(node) {
-      if (node.arguments.length > 1) {
-        const storeDefinerNode = node.arguments[1];
-
-        if (
-          isFunctionNode(storeDefinerNode)
-          && Array.isArray(storeDefinerNode?.body?.body)
-        ) {
-          const storeSetupFunctionBody = storeDefinerNode.body.body;
-          const groupedNodes = getGroupedNodesInStoreSetup(storeSetupFunctionBody);
-
-          storeDefinitions.push({ storeSetupNode: node, groupedNodes });
-        }
-      }
-    }
-
-    function addNodeToStoreDefinition(node, nodeType) {
-      const storeItem = storeDefinitions.find(storeDefinition => {
-        return !!getAncestorNode(node, ancestorNode => {
-          return ancestorNode === storeDefinition.storeSetupNode;
-        });
-      });
-
-      if (storeItem && Array.isArray(storeItem.groupedNodes[nodeType])) {
-        storeItem.groupedNodes[nodeType].push(node);
-      }
-    }
-
-    function getStateNodesThatAreAbsentInOtherGroups(groupedNodes) {
-      const { states, ...groupedNonStateNodes } = groupedNodes;
-
-      const nonStateNodes = Object.values(groupedNonStateNodes).flat();
-      const nonStateVariableNodes = nonStateNodes.map(node => {
-        return getParentNode(getAncestorNode(node, isVariableNode));
-      }).filter(Boolean);
-
-      return states.filter(stateNode => {
-        return !nonStateVariableNodes.includes(stateNode);
-      });
-    }
-
-    function getFilledStoreDefinitions() {
-      return storeDefinitions.map(storeDefinition => {
-        return {
-          ...storeDefinition,
-          groupedNodes: {
-            ...storeDefinition.groupedNodes,
-            states: getStateNodesThatAreAbsentInOtherGroups(storeDefinition.groupedNodes),
-          },
-        };
-      }).filter(storeDefinition => {
-        return Object.values(storeDefinition.groupedNodes).flat().length > 0;
-      });
-    }
-
     return {
       Program() {
         const tracker = new ReferenceTracker(context.getScope());
@@ -197,20 +126,27 @@ module.exports = {
         };
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.piniaDefineStore)) {
-          addStoreDefinition(node);
+          if (isValidStoreDefinition) {
+            const groupedNodes = getGroupedNodesInStoreSetup(
+              getChildNodesInStoreSetup(node),
+              getInitialGroupedNodes(),
+            );
+
+            storeDefinitions.push({ storeSetupNode: node, groupedNodes });
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.computedProperties)) {
-          addNodeToStoreDefinition(node, 'computedProperties');
+          addNodeToStoreDefinition(storeDefinitions, node, 'computedProperties');
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.watchers)) {
-          addNodeToStoreDefinition(node, 'watchers');
+          addNodeToStoreDefinition(storeDefinitions, node, 'watchers');
         }
       },
       // eslint-disable-next-line object-shorthand
       'Program:exit'() {
-        storeDefinitions = getFilledStoreDefinitions();
+        storeDefinitions = getFilledStoreDefinitions(storeDefinitions);
 
         storeDefinitions.forEach(storeDefinition => {
           const { groupedNodes } = storeDefinition;

--- a/lib/rules/pinia-setup-order.js
+++ b/lib/rules/pinia-setup-order.js
@@ -1,15 +1,15 @@
 const { ReferenceTracker } = require('eslint-utils');
 const {
   upperFirst,
-  getParentNode,
-  isVariableNode,
-  isFunctionNode,
-  getAncestorNode,
   getPiniaGroupOrder,
   getWatchersTraceMap,
+  isValidStoreDefinition,
   piniaDefineStoreTraceMap,
+  addNodeToStoreDefinition,
   getHumanizedVueGroupName,
-  isFunctionDeclarationNode,
+  getChildNodesInStoreSetup,
+  getFilledStoreDefinitions,
+  getGroupedNodesInStoreSetup,
   getComputedPropertiesTraceMap,
 } = require('../utils');
 
@@ -29,77 +29,6 @@ module.exports = {
       return Object.fromEntries(order.map(groupType => [groupType, []]));
     }
 
-    function getGroupedNodesInStoreSetup(storeSetupFunctionBody) {
-      const groupedNodes = getInitialGroupedNodes();
-
-      storeSetupFunctionBody.forEach(node => {
-        if (isVariableNode(node)) {
-          groupedNodes.states.push(node);
-        }
-
-        if (isFunctionDeclarationNode(node)) {
-          groupedNodes.methods.push(node);
-        }
-      });
-
-      return groupedNodes;
-    }
-
-    function addStoreDefinition(node) {
-      if (node.arguments.length > 1) {
-        const storeDefinerNode = node.arguments[1];
-
-        if (
-          isFunctionNode(storeDefinerNode)
-          && Array.isArray(storeDefinerNode?.body?.body)
-        ) {
-          const storeSetupFunctionBody = storeDefinerNode.body.body;
-          const groupedNodes = getGroupedNodesInStoreSetup(storeSetupFunctionBody);
-
-          storeDefinitions.push({ storeSetupNode: node, groupedNodes });
-        }
-      }
-    }
-
-    function addNodeToStoreDefinition(node, nodeType) {
-      const storeItem = storeDefinitions.find(storeDefinition => {
-        return !!getAncestorNode(node, ancestorNode => {
-          return ancestorNode === storeDefinition.storeSetupNode;
-        });
-      });
-
-      if (storeItem && Array.isArray(storeItem.groupedNodes[nodeType])) {
-        storeItem.groupedNodes[nodeType].push(node);
-      }
-    }
-
-    function getStateNodesThatAreAbsentInOtherGroups(groupedNodes) {
-      const { states, ...groupedNonStateNodes } = groupedNodes;
-
-      const nonStateNodes = Object.values(groupedNonStateNodes).flat();
-      const nonStateVariableNodes = nonStateNodes.map(node => {
-        return getParentNode(getAncestorNode(node, isVariableNode));
-      }).filter(Boolean);
-
-      return states.filter(stateNode => {
-        return !nonStateVariableNodes.includes(stateNode);
-      });
-    }
-
-    function getFilledStoreDefinitions() {
-      return storeDefinitions.map(storeDefinition => {
-        return {
-          ...storeDefinition,
-          groupedNodes: {
-            ...storeDefinition.groupedNodes,
-            states: getStateNodesThatAreAbsentInOtherGroups(storeDefinition.groupedNodes),
-          },
-        };
-      }).filter(storeDefinition => {
-        return Object.values(storeDefinition.groupedNodes).flat().length > 0;
-      });
-    }
-
     return {
       Program() {
         const tracker = new ReferenceTracker(context.getScope());
@@ -110,20 +39,27 @@ module.exports = {
         };
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.piniaDefineStore)) {
-          addStoreDefinition(node);
+          if (isValidStoreDefinition) {
+            const groupedNodes = getGroupedNodesInStoreSetup(
+              getChildNodesInStoreSetup(node),
+              getInitialGroupedNodes(),
+            );
+
+            storeDefinitions.push({ storeSetupNode: node, groupedNodes });
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.computedProperties)) {
-          addNodeToStoreDefinition(node, 'computedProperties');
+          addNodeToStoreDefinition(storeDefinitions, node, 'computedProperties');
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.watchers)) {
-          addNodeToStoreDefinition(node, 'watchers');
+          addNodeToStoreDefinition(storeDefinitions, node, 'watchers');
         }
       },
       // eslint-disable-next-line object-shorthand
       'Program:exit'() {
-        storeDefinitions = getFilledStoreDefinitions();
+        storeDefinitions = getFilledStoreDefinitions(storeDefinitions);
 
         storeDefinitions.forEach(storeDefinition => {
           for (const [groupName, nodes] of Object.entries(storeDefinition.groupedNodes)) {

--- a/lib/rules/vue-script-setup-newlines-between-groups.js
+++ b/lib/rules/vue-script-setup-newlines-between-groups.js
@@ -5,6 +5,7 @@ const {
   defineScriptSetupVisitor,
 } = require('../utils/vue-utils');
 const {
+  isVueRootNode,
   getVueGroupOrder,
   getHooksTraceMap,
   getWatchersTraceMap,
@@ -71,15 +72,21 @@ module.exports = {
         };
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.computedProperties)) {
-          groupedNodes.computedProperties.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.computedProperties.push(node);
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.watchers)) {
-          groupedNodes.watchers.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.watchers.push(node);
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.hooks)) {
-          groupedNodes.hooks.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.hooks.push(node);
+          }
         }
       },
       // eslint-disable-next-line object-shorthand

--- a/lib/rules/vue-script-setup-newlines-inside-groups.js
+++ b/lib/rules/vue-script-setup-newlines-inside-groups.js
@@ -5,6 +5,7 @@ const {
   defineScriptSetupVisitor,
 } = require('../utils/vue-utils');
 const {
+  isVueRootNode,
   getVueGroupOrder,
   getHooksTraceMap,
   getWatchersTraceMap,
@@ -143,15 +144,21 @@ module.exports = {
         };
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.computedProperties)) {
-          groupedNodes.computedProperties.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.computedProperties.push(node);
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.watchers)) {
-          groupedNodes.watchers.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.watchers.push(node);
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.hooks)) {
-          groupedNodes.hooks.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.hooks.push(node);
+          }
         }
       },
       // eslint-disable-next-line object-shorthand

--- a/lib/rules/vue-script-setup-order.js
+++ b/lib/rules/vue-script-setup-order.js
@@ -6,6 +6,7 @@ const {
 } = require('../utils/vue-utils');
 const {
   upperFirst,
+  isVueRootNode,
   getVueGroupOrder,
   getHooksTraceMap,
   getWatchersTraceMap,
@@ -46,15 +47,21 @@ module.exports = {
         };
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.computedProperties)) {
-          groupedNodes.computedProperties.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.computedProperties.push(node);
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.watchers)) {
-          groupedNodes.watchers.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.watchers.push(node);
+          }
         }
 
         for (const { node } of tracker.iterateEsmReferences(traceMaps.hooks)) {
-          groupedNodes.hooks.push(node);
+          if (isVueRootNode(node)) {
+            groupedNodes.hooks.push(node);
+          }
         }
       },
       // eslint-disable-next-line object-shorthand

--- a/lib/utils/groups.js
+++ b/lib/utils/groups.js
@@ -1,5 +1,5 @@
-const { getParentNode, isVariableNode, getAncestorNode } = require('./nodes');
 const { defaultPluginSettings, getSetting } = require('./plugin');
+const { getParentNode, isVariableNode, getAncestorNode } = require('./nodes');
 
 const vueComponentGroups = defaultPluginSettings.vue.groupOrder;
 const piniaGroups = defaultPluginSettings.vue.piniaGroupOrder;

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -2,6 +2,10 @@ function upperFirst(givenString) {
   return givenString.charAt(0).toUpperCase() + givenString.slice(1);
 }
 
+function arrayWrap(value) {
+  return Array.isArray(value) ? value : [value];
+}
+
 function objectGet(givenObject, path, defaultValue) {
   if (!path) {
     return undefined;
@@ -32,6 +36,7 @@ function getNumbersBetween(startNumber, endNumber, includeStartAndEnd = false) {
 }
 
 module.exports = {
+  arrayWrap,
   objectGet,
   upperFirst,
   getNumbersBetween,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -4,6 +4,7 @@ const pluginUtils = require('./plugin');
 const nodeUtils = require('./nodes');
 const groupUtils = require('./groups');
 const traceMapUtils = require('./trace-maps');
+const piniaUtils = require('./pinia');
 
 module.exports = {
   ...nodeUtils,
@@ -11,4 +12,5 @@ module.exports = {
   ...pluginUtils,
   ...helperUtils,
   ...traceMapUtils,
+  ...piniaUtils,
 };

--- a/lib/utils/nodes.js
+++ b/lib/utils/nodes.js
@@ -1,5 +1,9 @@
 const { getNumbersBetween } = require('./helpers');
 
+function isProgramNode(node) {
+  return node?.type === 'Program';
+}
+
 function isVariableNode(node) {
   return node?.type === 'VariableDeclaration' || (
     node?.type === 'VariableDeclarator' && node?.parent?.type === 'VariableDeclaration'
@@ -16,6 +20,12 @@ function isFunctionNode(node) {
 
 function isFunctionDeclarationNode(node) {
   return node?.type === 'FunctionDeclaration';
+}
+
+function isFunctionCallNode(node) {
+  return node?.type === 'ExpressionStatement' || (
+    node?.type === 'CallExpression' && node?.parent?.type === 'ExpressionStatement'
+  );
 }
 
 function getParentNode(node) {
@@ -76,11 +86,22 @@ function getNumberOfEmptyLinesBetween(context, node1, node2, ignoreComments = fa
   }).length;
 }
 
+function isVueRootNode(node) {
+  if (isVariableNode(node?.parent) || isFunctionCallNode(node?.parent)) {
+    return isProgramNode(node?.parent?.parent) || isProgramNode(node?.parent?.parent?.parent);
+  }
+
+  return isProgramNode(node?.parent);
+}
+
 module.exports = {
+  isProgramNode,
+  isVueRootNode,
   getParentNode,
   isVariableNode,
   isFunctionNode,
   getAncestorNode,
+  isFunctionCallNode,
   getCommentTokensBetween,
   isFunctionDeclarationNode,
   getNumberOfEmptyLinesBetween,

--- a/lib/utils/pinia.js
+++ b/lib/utils/pinia.js
@@ -1,0 +1,98 @@
+const {
+  isVariableNode,
+  isFunctionNode,
+  getAncestorNode,
+  isFunctionCallNode,
+  isFunctionDeclarationNode,
+} = require('./nodes');
+const { arrayWrap } = require('./helpers');
+const { getStateNodesThatAreAbsentInOtherGroups } = require('./groups');
+
+function isStoreRootNode(storeSetupFunctionNode, node) {
+  if (isVariableNode(node?.parent) || isFunctionCallNode(node?.parent)) {
+    const possibleParentRootNodes = [
+      node?.parent?.parent?.parent,
+      node?.parent?.parent?.parent?.parent,
+    ];
+
+    return possibleParentRootNodes.includes(storeSetupFunctionNode);
+  }
+
+  return node?.parent === storeSetupFunctionNode;
+}
+
+function isValidStoreDefinition(node) {
+  if (node.arguments.length > 1) {
+    const storeDefinerNode = node.arguments[1];
+
+    return isFunctionNode(storeDefinerNode)
+      && Array.isArray(storeDefinerNode?.body?.body);
+  }
+
+  return false;
+}
+
+function getChildNodesInStoreSetup(node) {
+  if (isValidStoreDefinition(node)) {
+    return node.arguments[1].body.body;
+  }
+
+  return [];
+}
+
+function getFilledStoreDefinitions(storeDefinitions) {
+  return storeDefinitions.map(storeDefinition => {
+    return {
+      ...storeDefinition,
+      groupedNodes: {
+        ...storeDefinition.groupedNodes,
+        states: getStateNodesThatAreAbsentInOtherGroups(storeDefinition.groupedNodes),
+      },
+    };
+  }).filter(storeDefinition => {
+    return Object.values(storeDefinition.groupedNodes).flat().length > 0;
+  });
+}
+
+function addNodeToStoreDefinition(storeDefinitions, node, groupType) {
+  const storeItem = storeDefinitions.find(storeDefinition => {
+    const { storeSetupNode } = storeDefinition;
+    const storeSetupFunction = storeSetupNode.arguments[1];
+    const isAncestorCallback = ancestor => ancestor === storeSetupFunction;
+
+    return isStoreRootNode(storeSetupFunction, node)
+      && !!getAncestorNode(node, isAncestorCallback);
+  });
+
+  if (storeItem && Array.isArray(storeItem.groupedNodes[groupType])) {
+    storeItem.groupedNodes[groupType].push(node);
+  }
+}
+
+function getGroupedNodesInStoreSetup(storeSetupFunctionBody, initialGroupedNodes) {
+  const groupedNodes = initialGroupedNodes;
+
+  storeSetupFunctionBody.forEach(node => {
+    if (isVariableNode(node)) {
+      const isVariableDeclaration = node.type === 'VariableDeclaration';
+      const variableNodes = arrayWrap(isVariableDeclaration ? node.declarations : node);
+
+      groupedNodes.states.push(...variableNodes);
+    }
+
+    if (isFunctionDeclarationNode(node)) {
+      groupedNodes.methods.push(node);
+    }
+  });
+
+  return groupedNodes;
+}
+
+module.exports = {
+  isStoreRootNode,
+  isValidStoreDefinition,
+  addNodeToStoreDefinition,
+  getChildNodesInStoreSetup,
+  getFilledStoreDefinitions,
+  getGroupedNodesInStoreSetup,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@programic/eslint-plugin",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Official ESLint plugin for Programic",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
This PR fixes some issues in the rules that use grouped nodes. From now on, only root nodes are included as grouped nodes. I also extracted some repeated code into utils/helper files.