### PR TITLE
Updated rules according to Vue 3.3 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Before using any config or rule from this package, you should include the necess
 |-----------------------------------|-------------|---------|------------|---------|----------------|
 | eslint                            | ^8.2.0      | ^8.2.0  | ^8.2.0     | ^8.2.0  | ^8.2.0         |
 | eslint-plugin-import              | -           | ^2.27.5 | ^2.27.5    | ^2.27.5 | ^2.27.5        |
-| eslint-plugin-import-newlines     | -           | ^1.3.1  | ^1.3.1     | ^1.3.1  | ^1.3.1         |
 | eslint-plugin-unicorn             | -           | ^45.0.2 | ^45.0.2    | ^45.0.2 | ^45.0.2        |
 | eslint-config-airbnb-base         | -           | ^15.0.0 | ^15.0.0    | ^15.0.0 | ^15.0.0        |
 | tailwindcss                       | ^3.2.7      | -       | -          | -       | -              |

--- a/docs/rules/vue-script-setup-newlines-between-groups.md
+++ b/docs/rules/vue-script-setup-newlines-between-groups.md
@@ -12,14 +12,17 @@ This rule enforces newlines between groups in Vue script setup tag.
 
 Below are the different groups (default):
 1. Import declarations
-2. Props (`defineProps`)
-3. Emits (`defineEmits`)
-4. States (`Any variable that is not part of another group`)
-5. Computed properties (`computed`)
-6. Watchers (`watch`, `watchEffect`, `watchSyncEffect`, `watchPostEffect`)
-7. Lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, `onBeforeMount`, `onBeforeUpdate`, `onBeforeUnmount`, `onErrorCaptured`, `onRenderTracked`, `onRenderTriggered`, `onActivated`, `onDeactivated`, `onServerPrefetch`)
-8. Methods (`Any function statement`)
-9. Expose (`defineExpose`)
+2. Models (`defineModel`)
+3. Props (`defineProps`)
+4. Emits (`defineEmits`)
+5. Slots (`defineSlots`)
+6. States (`Any variable that is not part of another group`)
+7. Computed properties (`computed`)
+8. Watchers (`watch`, `watchEffect`, `watchSyncEffect`, `watchPostEffect`)
+9. Lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, `onBeforeMount`, `onBeforeUpdate`, `onBeforeUnmount`, `onErrorCaptured`, `onRenderTracked`, `onRenderTriggered`, `onActivated`, `onDeactivated`, `onServerPrefetch`)
+10. Methods (`Any function statement`)
+11. Expose (`defineExpose`)
+12. Options (`defineOptions`)
 
 The order of the groups is determined by the settings object. Please read the [settings docs](https://github.com/programic/eslint-plugin/blob/master/docs/settings.md).
 

--- a/docs/rules/vue-script-setup-newlines-inside-groups.md
+++ b/docs/rules/vue-script-setup-newlines-inside-groups.md
@@ -11,11 +11,12 @@
 This rule enforces newlines inside groups in Vue script setup tag.
 
 Below are the different groups (default):
-1. States (`Any variable that is not part of another group`)
-2. Computed properties (`computed`)
-3. Watchers (`watch`, `watchEffect`, `watchSyncEffect`, `watchPostEffect`)
-4. Lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, `onBeforeMount`, `onBeforeUpdate`, `onBeforeUnmount`, `onErrorCaptured`, `onRenderTracked`, `onRenderTriggered`, `onActivated`, `onDeactivated`, `onServerPrefetch`)
-5. Methods (`Any function statement`)
+1. defineModel (`Any variable that is not part of another group`)
+2. States (`Any variable that is not part of another group`)
+3. Computed properties (`computed`)
+4. Watchers (`watch`, `watchEffect`, `watchSyncEffect`, `watchPostEffect`)
+5. Lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, `onBeforeMount`, `onBeforeUpdate`, `onBeforeUnmount`, `onErrorCaptured`, `onRenderTracked`, `onRenderTriggered`, `onActivated`, `onDeactivated`, `onServerPrefetch`)
+6. Methods (`Any function statement`)
 
 The order of the groups is determined by the settings object. Please read the [settings docs](https://github.com/programic/eslint-plugin/blob/master/docs/settings.md).
 
@@ -26,6 +27,11 @@ You can set the `newlines` option to set the number of expected newlines for all
 {
   "@programic/vue-script-setup-newlines-inside-groups": ["error", {
     "newlines": {
+      "numberOfNewlinesBetweenSingleLineItems": 0,
+      "numberOfNewlinesBetweenSingleAndMultiLineItems": 0,
+      "numberOfNewlinesBetweenMultiLineItems": 0
+    },
+    "defineModel": {
       "numberOfNewlinesBetweenSingleLineItems": 0,
       "numberOfNewlinesBetweenSingleAndMultiLineItems": 0,
       "numberOfNewlinesBetweenMultiLineItems": 0

--- a/docs/rules/vue-script-setup-order.md
+++ b/docs/rules/vue-script-setup-order.md
@@ -10,14 +10,17 @@ This rule enforces a specific order in Vue components inside the script setup ta
 
 The order is seperated into multiple groups. The default group order is:
 1. Import declarations
-2. Props (`defineProps`)
-3. Emits (`defineEmits`)
-4. States (`Any variable that is not part of another group`)
-5. Computed properties (`computed`)
-6. Watchers (`watch`, `watchEffect`, `watchSyncEffect`, `watchPostEffect`)
-7. Lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, `onBeforeMount`, `onBeforeUpdate`, `onBeforeUnmount`, `onErrorCaptured`, `onRenderTracked`, `onRenderTriggered`, `onActivated`, `onDeactivated`, `onServerPrefetch`)
-8. Methods (`Any function statement`)
-9. Expose (`defineExpose`)
+2. Models (`defineModel`)
+3. Props (`defineProps`)
+4. Emits (`defineEmits`)
+5. Slots (`defineSlots`)
+6. States (`Any variable that is not part of another group`)
+7. Computed properties (`computed`)
+8. Watchers (`watch`, `watchEffect`, `watchSyncEffect`, `watchPostEffect`)
+9. Lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, `onBeforeMount`, `onBeforeUpdate`, `onBeforeUnmount`, `onErrorCaptured`, `onRenderTracked`, `onRenderTriggered`, `onActivated`, `onDeactivated`, `onServerPrefetch`)
+10. Methods (`Any function statement`)
+11. Expose (`defineExpose`)
+12. Options (`defineOptions`)
 
 You can change the order via the `settings` options. Please read the [settings docs](https://github.com/programic/eslint-plugin/blob/master/docs/settings.md).
 

--- a/lib/configs/base.js
+++ b/lib/configs/base.js
@@ -6,7 +6,6 @@ module.exports = {
   plugins: [
     'import',
     'unicorn',
-    'import-newlines',
   ],
 
   extends: [
@@ -70,10 +69,6 @@ module.exports = {
       ignoreTrailingComments: false,
     }],
     eqeqeq: 'error',
-    'import-newlines/enforce': ['error', {
-      items: 3,
-      'max-len': 120,
-    }],
     'import/no-named-as-default': 'off',
     'unicorn/better-regex': 'error',
     'unicorn/catch-error-name': 'error',

--- a/lib/configs/vue.js
+++ b/lib/configs/vue.js
@@ -202,6 +202,8 @@ module.exports = {
         },
       },
     }],
+    'vue/prefer-define-options': 'error',
+    'vue/valid-define-options': 'error',
     'vue/arrow-spacing': 'error',
     'vue/array-bracket-spacing': ['error', 'never'],
     'vue/comma-dangle': ['error', 'always-multiline'],

--- a/lib/rules/vue-no-compiler-macro-imports.js
+++ b/lib/rules/vue-no-compiler-macro-imports.js
@@ -21,6 +21,9 @@ module.exports = {
     const compilerMacros = [
       'defineProps',
       'defineEmits',
+      'defineSlots',
+      'defineModel',
+      'defineOptions',
       'defineExpose',
       'withDefaults',
     ];

--- a/lib/rules/vue-script-setup-newlines-between-groups.js
+++ b/lib/rules/vue-script-setup-newlines-between-groups.js
@@ -112,10 +112,6 @@ module.exports = {
       'Program > ImportDeclaration'(node) {
         groupedNodes.imports.push(node);
       },
-      // eslint-disable-next-line object-shorthand
-      'Program > VariableDeclaration > VariableDeclarator'(node) {
-        groupedNodes.states.push(node);
-      },
       // eslint-disable-next-line unicorn/prevent-abbreviations
       onDefinePropsExit(node) {
         groupedNodes.defineProps.push(node);
@@ -124,12 +120,28 @@ module.exports = {
         groupedNodes.defineEmits.push(node);
       },
       // eslint-disable-next-line object-shorthand
-      'Program > FunctionDeclaration'(node) {
-        groupedNodes.methods.push(node);
+      'ExpressionStatement > CallExpression[callee.name="defineModel"]'(node) {
+        groupedNodes.defineModel.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineSlots"]'(node) {
+        groupedNodes.defineSlots.push(node);
       },
       // eslint-disable-next-line object-shorthand
       'ExpressionStatement > CallExpression[callee.name="defineExpose"]'(node) {
         groupedNodes.defineExpose.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineOptions"]'(node) {
+        groupedNodes.defineOptions.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'Program > VariableDeclaration > VariableDeclarator'(node) {
+        groupedNodes.states.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'Program > FunctionDeclaration'(node) {
+        groupedNodes.methods.push(node);
       },
     }));
   },

--- a/lib/rules/vue-script-setup-newlines-inside-groups.js
+++ b/lib/rules/vue-script-setup-newlines-inside-groups.js
@@ -167,6 +167,9 @@ module.exports = {
 
         delete groupedNodes.defineProps;
         delete groupedNodes.defineEmits;
+        delete groupedNodes.defineSlots;
+        delete groupedNodes.defineOptions;
+        delete groupedNodes.defineExpose;
 
         for (const [groupType, nodes] of Object.entries(groupedNodes)) {
           nodes.forEach((node, index) => {
@@ -187,6 +190,22 @@ module.exports = {
       },
       onDefineEmitsExit(node) {
         groupedNodes.defineEmits.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineModel"]'(node) {
+        groupedNodes.defineModel.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineSlots"]'(node) {
+        groupedNodes.defineSlots.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineExpose"]'(node) {
+        groupedNodes.defineExpose.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineOptions"]'(node) {
+        groupedNodes.defineOptions.push(node);
       },
       // eslint-disable-next-line object-shorthand
       'Program > FunctionDeclaration'(node) {

--- a/lib/rules/vue-script-setup-order.js
+++ b/lib/rules/vue-script-setup-order.js
@@ -120,10 +120,6 @@ module.exports = {
       'Program > ImportDeclaration'(node) {
         groupedNodes.imports.push(node);
       },
-      // eslint-disable-next-line object-shorthand
-      'Program > VariableDeclaration > VariableDeclarator'(node) {
-        groupedNodes.states.push(node);
-      },
       // eslint-disable-next-line unicorn/prevent-abbreviations
       onDefinePropsExit(node) {
         groupedNodes.defineProps.push(node);
@@ -132,12 +128,28 @@ module.exports = {
         groupedNodes.defineEmits.push(node);
       },
       // eslint-disable-next-line object-shorthand
-      'Program > FunctionDeclaration'(node) {
-        groupedNodes.methods.push(node);
+      'ExpressionStatement > CallExpression[callee.name="defineModel"]'(node) {
+        groupedNodes.defineModel.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineSlots"]'(node) {
+        groupedNodes.defineSlots.push(node);
       },
       // eslint-disable-next-line object-shorthand
       'ExpressionStatement > CallExpression[callee.name="defineExpose"]'(node) {
         groupedNodes.defineExpose.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'ExpressionStatement > CallExpression[callee.name="defineOptions"]'(node) {
+        groupedNodes.defineOptions.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'Program > VariableDeclaration > VariableDeclarator'(node) {
+        groupedNodes.states.push(node);
+      },
+      // eslint-disable-next-line object-shorthand
+      'Program > FunctionDeclaration'(node) {
+        groupedNodes.methods.push(node);
       },
     }));
   },

--- a/lib/utils/groups.js
+++ b/lib/utils/groups.js
@@ -47,10 +47,16 @@ function getHumanizedVueGroupName(groupName) {
   switch (groupName) {
     case 'imports':
       return 'imports';
+    case 'defineModel':
+      return 'models';
     case 'defineProps':
       return 'props';
     case 'defineEmits':
       return 'emits';
+    case 'defineSlots':
+      return 'defineSlots';
+    case 'defineExpose':
+      return 'defineExpose';
     case 'states':
       return 'states';
     case 'computedProperties':
@@ -61,8 +67,6 @@ function getHumanizedVueGroupName(groupName) {
       return 'hooks';
     case 'methods':
       return 'methods';
-    case 'defineExpose':
-      return 'defineExpose';
     default:
       return groupName;
   }

--- a/lib/utils/plugin.js
+++ b/lib/utils/plugin.js
@@ -2,14 +2,17 @@ const { objectGet } = require('./helpers');
 
 const vueComponentGroups = Object.freeze([
   'imports',
+  'defineModel',
   'defineProps',
   'defineEmits',
+  'defineSlots',
   'states',
   'computedProperties',
   'watchers',
   'hooks',
   'methods',
   'defineExpose',
+  'defineOptions',
 ]);
 
 // Caution: this also will be used as group order!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@programic/eslint-plugin",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "description": "Official ESLint plugin for Programic",
   "main": "lib/index.js",
   "files": [
@@ -30,30 +30,29 @@
   },
   "homepage": "https://programic.com",
   "peerDependencies": {
-    "eslint": "^8.37.0"
+    "eslint": "^8.43.0"
   },
   "dependencies": {
-    "@typescript-eslint/scope-manager": "^5.57.0",
-    "@typescript-eslint/utils": "^5.57.0",
+    "@typescript-eslint/scope-manager": "^5.60.0",
+    "@typescript-eslint/utils": "^5.60.0",
     "eslint-utils": "^3.0.0"
   },
   "devDependencies": {
-    "@types/eslint": "^8.37.0",
-    "@types/jest": "^29.4.0",
-    "@typescript-eslint/eslint-plugin": "^5.57.0",
-    "@typescript-eslint/parser": "^5.57.0",
+    "@types/eslint": "^8.40.2",
+    "@types/jest": "^29.5.2",
+    "@typescript-eslint/eslint-plugin": "^5.60.0",
+    "@typescript-eslint/parser": "^5.60.0",
     "eslint": "^8.37.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-import-resolver-typescript": "^3.5.4",
     "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-import-newlines": "^1.3.1",
-    "eslint-plugin-jest": "^27.2.1",
-    "eslint-plugin-tailwindcss": "^3.10.3",
-    "eslint-plugin-unicorn": "^46.0.0",
-    "eslint-plugin-vue": "^9.9.0",
+    "eslint-plugin-jest": "^27.2.2",
+    "eslint-plugin-tailwindcss": "^3.12.1",
+    "eslint-plugin-unicorn": "^47.0.0",
+    "eslint-plugin-vue": "^9.15.1",
     "jest": "^29.4.3",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5",
-    "vue-eslint-parser": "^9.1.1"
+    "vue-eslint-parser": "^9.3.1"
   }
 }


### PR DESCRIPTION
- Bumped dependencies
- Applied Vue 3.3 features to current rules and updated docs
- Removed import-newlines/enforce rule and therefore eslint-plugin-import-newlines
- Applied vue/prefer-define-options and vue/valid-define-options because it's in line with our current rules